### PR TITLE
PRO-2774 Append dedup support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build
 
 BINARY=propel-airbyte-destination
-VERSION=0.0.1
+VERSION=0.0.2
 
 build: build-amd64 build-arm64
 
@@ -17,7 +17,7 @@ secrets:
 	echo '{"application_id": "$(APP_ID)", "application_secret": "$(SECRET)"}' > secrets/config.json
 
 push-docker:
-	docker buildx build -t propeldata/airbyte-propel-destination:$(VERSION) --platform linux/amd64,linux/arm64 . --push --build-arg VERSION=$(VERSION)
+	docker buildx build -t propeldata/airbyte-propel-destination:$(VERSION) -t propeldata/airbyte-propel-destination:latest --platform linux/amd64,linux/arm64 . --push --build-arg VERSION=$(VERSION)
 
 test:
 	go test -v ./internal/...

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -59,7 +59,7 @@ func TestWrite(t *testing.T) {
 			dataGrid, err := apiClient.FetchDataGrid(ctx, models.DataGridInput{
 				DataPool: models.DataPoolInput{Name: dataSourceUniqueName},
 				Columns:  []string{"id", "name"},
-				TimeRange: models.TimeRangeInput{
+				TimeRange: &models.TimeRangeInput{
 					Relative: "LAST_N_DAYS",
 					N:        365,
 					Start:    time.Unix(1705379000, 0),

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -56,7 +56,7 @@ func TestWrite(t *testing.T) {
 	c.Len(overwriteDS.ConnectionSettings.WebhookConnectionSettings.Columns, 4)
 	c.Equal("_airbyte_raw_id", overwriteDS.ConnectionSettings.WebhookConnectionSettings.UniqueID)
 
-	dedupDS, err := apiClient.FetchDataSource(ctx, overwriteDataSourceName)
+	dedupDS, err := apiClient.FetchDataSource(ctx, dedupDataSourceName)
 	c.NoError(err)
 	c.Len(dedupDS.ConnectionSettings.WebhookConnectionSettings.Columns, 5)
 	c.Equal([]string{"id"}, dedupDS.ConnectionSettings.WebhookConnectionSettings.TableSettings.OrderBy)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.3
 
 require (
 	github.com/google/uuid v1.5.0
-	github.com/propeldata/go-client v0.0.0-20240312131722-8eb995d265ee
+	github.com/propeldata/go-client v0.0.0-20240319165123-1cfcf03faf4b
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.2.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.3
 
 require (
 	github.com/google/uuid v1.5.0
-	github.com/propeldata/go-client v0.0.0-20240212132900-b257c0be6b3f
+	github.com/propeldata/go-client v0.0.0-20240312131722-8eb995d265ee
 	github.com/sethvargo/go-password v0.2.0
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/propeldata/go-client v0.0.0-20240212132900-b257c0be6b3f h1:ih63JIXIXa
 github.com/propeldata/go-client v0.0.0-20240212132900-b257c0be6b3f/go.mod h1:66MbzHOEKlqy8HDZpIeof8systvvO9Tg7e92lZWSrBw=
 github.com/propeldata/go-client v0.0.0-20240312131722-8eb995d265ee h1:C84YBBkah6VxitatvjLI6gd7KX0vARgrvoWOque+4dg=
 github.com/propeldata/go-client v0.0.0-20240312131722-8eb995d265ee/go.mod h1:66MbzHOEKlqy8HDZpIeof8systvvO9Tg7e92lZWSrBw=
+github.com/propeldata/go-client v0.0.0-20240319165123-1cfcf03faf4b h1:iB+GHl50WcrPiJrkTdokRhEdCnZtjO8dpzU+DkihU4s=
+github.com/propeldata/go-client v0.0.0-20240319165123-1cfcf03faf4b/go.mod h1:SnF0U3Ior97upM7kNxFpY2cG2wYg2jSlv8MM5B1chzE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
 github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/propeldata/go-client v0.0.0-20240206195329-6429118ee9c3 h1:0unp9rDeB8
 github.com/propeldata/go-client v0.0.0-20240206195329-6429118ee9c3/go.mod h1:66MbzHOEKlqy8HDZpIeof8systvvO9Tg7e92lZWSrBw=
 github.com/propeldata/go-client v0.0.0-20240212132900-b257c0be6b3f h1:ih63JIXIXaEqXuf1sqBx+zv5AolcgXUqvIAUAwIGaK8=
 github.com/propeldata/go-client v0.0.0-20240212132900-b257c0be6b3f/go.mod h1:66MbzHOEKlqy8HDZpIeof8systvvO9Tg7e92lZWSrBw=
+github.com/propeldata/go-client v0.0.0-20240312131722-8eb995d265ee h1:C84YBBkah6VxitatvjLI6gd7KX0vARgrvoWOque+4dg=
+github.com/propeldata/go-client v0.0.0-20240312131722-8eb995d265ee/go.mod h1:66MbzHOEKlqy8HDZpIeof8systvvO9Tg7e92lZWSrBw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
 github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=

--- a/internal/connector/destination.go
+++ b/internal/connector/destination.go
@@ -304,7 +304,7 @@ func (d *Destination) buildAndCreateDataSource(ctx context.Context, configuredSt
 	}
 
 	if len(orderByColumns) == 0 && configuredStream.DestinationSyncMode == airbyte.DestinationSyncModeAppendDedup {
-		d.logger.Log(airbyte.LogLevelError, fmt.Sprintf("Append Dedup sync mode requires at least 1 primary key"))
+		d.logger.Log(airbyte.LogLevelError, fmt.Sprintf("Append Dedup sync mode requires at least 1 primary key column"))
 		return nil, fmt.Errorf("no primary keys were found for Data Source %q", dataSourceUniqueName)
 	}
 

--- a/internal/connector/destination.go
+++ b/internal/connector/destination.go
@@ -415,6 +415,8 @@ func (d *Destination) writeRecords(ctx context.Context, input io.Reader, dataSou
 			recordMap[airbyteExtractedAtColumn] = airbyteMessage.Record.EmittedAt
 
 			dataSource := dataSources[getDataSourceUniqueName(airbyteMessage.Record.Namespace, airbyteMessage.Record.Stream)]
+			fmt.Println("data source unique name is...")
+			fmt.Println(getDataSourceUniqueName(airbyteMessage.Record.Namespace, airbyteMessage.Record.Stream))
 			if len(batchedRecordsPerDataSource[dataSource.UniqueName]) == maxRecordsBatchSize {
 				eventsInput := &client.PostEventsInput{
 					WebhookURL:   dataSource.ConnectionSettings.WebhookConnectionSettings.WebhookURL,

--- a/internal/connector/destination.go
+++ b/internal/connector/destination.go
@@ -478,10 +478,12 @@ func getDataSourceUniqueName(namespace, streamName string) string {
 
 func getAirbyteRawID(namespace, streamName string, recordIndex int, emittedAt int64) string {
 	hash := sha256.New()
-	hash.Write([]byte(strings.Join([]string{namespace, streamName, strconv.Itoa(recordIndex), strconv.FormatInt(emittedAt, 10)}, ":")))
+	hash.Write([]byte(strings.Join([]string{namespace, streamName, strconv.Itoa(recordIndex), strconv.FormatInt(emittedAt, 10)}, "\000")))
 	hashBytes := hash.Sum(nil)
+	hexString := hex.EncodeToString(hashBytes)
+	uuid := hexString[:8] + "-" + hexString[8:12] + "-" + hexString[12:16] + "-" + hexString[16:20] + "-" + hexString[20:32]
 
-	return hex.EncodeToString(hashBytes)
+	return uuid
 }
 
 func ptr[T any](value T) *T {

--- a/internal/connector/destination.go
+++ b/internal/connector/destination.go
@@ -415,8 +415,6 @@ func (d *Destination) writeRecords(ctx context.Context, input io.Reader, dataSou
 			recordMap[airbyteExtractedAtColumn] = airbyteMessage.Record.EmittedAt
 
 			dataSource := dataSources[getDataSourceUniqueName(airbyteMessage.Record.Namespace, airbyteMessage.Record.Stream)]
-			fmt.Println("data source unique name is...")
-			fmt.Println(getDataSourceUniqueName(airbyteMessage.Record.Namespace, airbyteMessage.Record.Stream))
 			if len(batchedRecordsPerDataSource[dataSource.UniqueName]) == maxRecordsBatchSize {
 				eventsInput := &client.PostEventsInput{
 					WebhookURL:   dataSource.ConnectionSettings.WebhookConnectionSettings.WebhookURL,

--- a/internal/connector/destination.go
+++ b/internal/connector/destination.go
@@ -401,7 +401,7 @@ func (d *Destination) writeRecords(ctx context.Context, input io.Reader, dataSou
 			d.logger.State(airbyteMessage.State)
 		case airbyte.MessageTypeRecord:
 			recordMap := airbyteMessage.Record.Data
-			recordMap[airbyteRawIdColumn] = getAirbyteRawID(airbyteMessage.Record.Namespace, airbyteMessage.Record.Stream, i)
+			recordMap[airbyteRawIdColumn] = getAirbyteRawID(airbyteMessage.Record.Namespace, airbyteMessage.Record.Stream, i, airbyteMessage.Record.EmittedAt)
 			recordMap[airbyteExtractedAtColumn] = airbyteMessage.Record.EmittedAt
 
 			dataSource := dataSources[getDataSourceUniqueName(airbyteMessage.Record.Namespace, airbyteMessage.Record.Stream)]
@@ -467,9 +467,9 @@ func getDataSourceUniqueName(namespace, streamName string) string {
 	return fmt.Sprintf("%s_%s", namespace, streamName)
 }
 
-func getAirbyteRawID(namespace, streamName string, recordIndex int) string {
+func getAirbyteRawID(namespace, streamName string, recordIndex int, emittedAt int64) string {
 	hash := sha256.New()
-	hash.Write([]byte(strings.Join([]string{namespace, streamName, strconv.Itoa(recordIndex)}, ":")))
+	hash.Write([]byte(strings.Join([]string{namespace, streamName, strconv.Itoa(recordIndex), strconv.FormatInt(emittedAt, 10)}, ":")))
 	hashBytes := hash.Sum(nil)
 
 	return hex.EncodeToString(hashBytes)

--- a/internal/connector/destination_mock.go
+++ b/internal/connector/destination_mock.go
@@ -175,11 +175,19 @@ func (ac *MockApiClient) FetchDataSource(_ context.Context, uniqueName string) (
 	}}
 }
 
+func (ac *MockApiClient) DeleteDataSource(_ context.Context, _ string) (string, error) {
+	return "DSO1234567", nil
+}
+
 func (ac *MockApiClient) FetchDataPool(_ context.Context, _ string) (*models.DataPool, error) {
 	return &models.DataPool{
 		ID:        "DPO1234567890",
 		Timestamp: models.Timestamp{ColumnName: airbyteExtractedAtColumn},
 	}, nil
+}
+
+func (ac *MockApiClient) DeleteDataPool(_ context.Context, _ string) (string, error) {
+	return "DPO1234567", nil
 }
 
 func (ac *MockApiClient) CreateDeletionJob(_ context.Context, _ string, _ []models.FilterInput) (*models.Job, error) {

--- a/internal/connector/destination_test.go
+++ b/internal/connector/destination_test.go
@@ -27,7 +27,7 @@ func TestDestination_Spec(t *testing.T) {
 
 	spec := d.Spec()
 	c.Equal("https://propeldata.com/docs", spec.DocumentationURL)
-	c.Equal([]airbyte.DestinationSyncMode{"overwrite", "append"}, spec.SupportedDestinationSyncModes)
+	c.Equal([]airbyte.DestinationSyncMode{"overwrite", "append", "append_dedup"}, spec.SupportedDestinationSyncModes)
 }
 
 func TestDestination_Check(t *testing.T) {
@@ -144,7 +144,6 @@ func TestDestination_Write(t *testing.T) {
 			inputDataPath:    inputDataPath,
 			mockWebhookError: errors.New("mock webhook error"),
 			expectedLogs: []string{
-				"Reading data for Data Source",
 				"failed to publish 2 events to url:",
 			},
 			expectedError: "publish batch failed after state",
@@ -159,7 +158,6 @@ func TestDestination_Write(t *testing.T) {
 				"airlines state 2",
 				"airlines state 3",
 				"Max batch size reached",
-				"Reading data for Data Source",
 				`Deletion Job \"DPJ1234567890\" succeeded`,
 			},
 		},

--- a/internal/connector/destination_test.go
+++ b/internal/connector/destination_test.go
@@ -196,3 +196,48 @@ func TestDestination_Write(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAirbyteRawID(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		streamName  string
+		recordIndex int
+		emittedAt   int64
+		expectedID  string
+	}{
+		{
+			name:        "No types",
+			namespace:   "namespace",
+			streamName:  "stream",
+			recordIndex: 1,
+			emittedAt:   int64(123456789),
+			expectedID:  "64835b23-1e43-d091-c9b0-de411c0d4364",
+		},
+		{
+			name:        "No types",
+			namespace:   "namespace",
+			streamName:  "stream",
+			recordIndex: 2,
+			emittedAt:   int64(123456789),
+			expectedID:  "8b7e81a5-412e-3f3e-f045-bc0c440bdc02",
+		},
+		{
+			name:        "No types",
+			namespace:   "namespace",
+			streamName:  "stream",
+			recordIndex: 1,
+			emittedAt:   int64(1323456789),
+			expectedID:  "245b33d5-9c69-cdfb-ae06-d1b753d62f1c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			a := assert.New(st)
+
+			id := getAirbyteRawID(tt.namespace, tt.streamName, tt.recordIndex, tt.emittedAt)
+			a.Equal(tt.expectedID, id)
+		})
+	}
+}

--- a/internal/connector/test_files/configured_catalog.json
+++ b/internal/connector/test_files/configured_catalog.json
@@ -45,6 +45,41 @@
           }
         }
       }
+    },
+    {
+      "sync_mode": "incremental",
+      "destination_sync_mode": "append_dedup",
+      "cursor_field": [
+        "updated_at"
+      ],
+      "primary_key": [
+        [
+          "id"
+        ]
+      ],
+      "stream": {
+        "name": "deduped stream",
+        "supported_sync_modes": [
+          "full_refresh",
+          "incremental"
+        ],
+        "source_defined_cursor": true,
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer"
+            },
+            "name": {
+              "type": ["null", "string"]
+            },
+            "updated_at": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -9,8 +9,6 @@ import (
 )
 
 func ConvertAirbyteTypeToPropelType(airbyteProperty airbyte.PropertyType) (models.PropelType, error) {
-	var propelType models.PropelType
-
 	if airbyteProperty.TypeSet == nil {
 		// if no general type is specified, default to string
 		return models.StringPropelType, nil
@@ -27,38 +25,28 @@ func ConvertAirbyteTypeToPropelType(airbyteProperty airbyte.PropertyType) (model
 		return models.StringPropelType, nil
 	}
 
-	for _, aType := range types {
-		switch aType {
-		case airbyte.String:
-			switch airbyteProperty.Format {
-			case airbyte.Date:
-				propelType = models.DatePropelType
-			case airbyte.DateTime:
-				switch airbyteProperty.AirbyteType {
-				case airbyte.TimestampWOTZ:
-					propelType = models.StringPropelType
-				default:
-					propelType = models.TimestampPropelType
-				}
-			case airbyte.Time:
-				propelType = models.StringPropelType
-			}
-
-			propelType = models.StringPropelType
-		case airbyte.Boolean:
-			propelType = models.BooleanPropelType
-		case airbyte.Number:
-			propelType = models.DoublePropelType
-		case airbyte.Integer:
-			propelType = models.Int64PropelType
-		case airbyte.Object, airbyte.Array:
-			propelType = models.JsonPropelType
-		default:
-			return models.PropelType{}, fmt.Errorf("airbyte type %s:%s:%s not supported", aType, airbyteProperty.Format, airbyteProperty.AirbyteType)
+	switch types[0] {
+	case airbyte.String:
+		switch airbyteProperty.Format {
+		case airbyte.Date:
+			return models.DatePropelType, nil
+		case airbyte.DateTime:
+			return models.TimestampPropelType, nil
+		case airbyte.Time:
+			return models.StringPropelType, nil
 		}
+		return models.StringPropelType, nil
+	case airbyte.Boolean:
+		return models.BooleanPropelType, nil
+	case airbyte.Number:
+		return models.DoublePropelType, nil
+	case airbyte.Integer:
+		return models.Int64PropelType, nil
+	case airbyte.Object, airbyte.Array:
+		return models.JsonPropelType, nil
+	default:
+		return models.PropelType{}, fmt.Errorf("airbyte type %s:%s:%s not supported", types[0], airbyteProperty.Format, airbyteProperty.AirbyteType)
 	}
-
-	return propelType, nil
 }
 
 func removeNullType(input []airbyte.PropType) []airbyte.PropType {

--- a/internal/connector/types_test.go
+++ b/internal/connector/types_test.go
@@ -13,6 +13,7 @@ func TestConvertAirbyteTypeToPropelType(t *testing.T) {
 	tests := []struct {
 		name               string
 		propTypes          []airbyte.PropType
+		format             airbyte.FormatType
 		expectedPropelType models.PropelType
 		expectedError      string
 	}{
@@ -26,6 +27,13 @@ func TestConvertAirbyteTypeToPropelType(t *testing.T) {
 			name:               "Multiple types",
 			propTypes:          []airbyte.PropType{airbyte.Null, airbyte.Object, airbyte.Integer},
 			expectedPropelType: models.StringPropelType,
+			expectedError:      "",
+		},
+		{
+			name:               "Date type",
+			propTypes:          []airbyte.PropType{airbyte.Null, airbyte.String},
+			format:             airbyte.DateTime,
+			expectedPropelType: models.TimestampPropelType,
 			expectedError:      "",
 		},
 		{
@@ -48,6 +56,7 @@ func TestConvertAirbyteTypeToPropelType(t *testing.T) {
 
 			propelType, err := ConvertAirbyteTypeToPropelType(airbyte.PropertyType{
 				TypeSet: &airbyte.PropTypes{Types: tt.propTypes},
+				Format:  tt.format,
 			})
 			a.Equal(tt.expectedPropelType, propelType)
 

--- a/sample_files/configured_catalog.json
+++ b/sample_files/configured_catalog.json
@@ -1,27 +1,58 @@
 {
-  "streams": [
-	{
-	  "sync_mode": "full_refresh",
-	  "destination_sync_mode": "overwrite",
-	  "stream": {
-		"name": "airbyte_airlines",
-		"supported_sync_modes": [
-		  "full_refresh",
-		  "incremental"
-		],
-		"source_defined_cursor": false,
-		"json_schema": {
-		  "type": "object",
-		  "properties": {
-			"id": {
-			  "type": "integer"
-			},
-			"name": {
-			  "type": "string"
+	"streams": [
+		{
+			"sync_mode": "full_refresh",
+			"destination_sync_mode": "overwrite",
+			"stream": {
+				"name": "airbyte_overwrite",
+				"supported_sync_modes": [
+					"full_refresh",
+					"incremental"
+				],
+				"source_defined_cursor": false,
+				"json_schema": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "integer"
+						},
+						"name": {
+							"type": "string"
+						}
+					}
+				}
 			}
-		  }
+		},
+		{
+			"sync_mode": "incremental",
+			"cursor_field": ["updated_at"],
+			"primary_key": [
+				["id"]
+			],
+			"destination_sync_mode": "append_dedup",
+			"stream": {
+				"name": "airbyte_dedup",
+				"supported_sync_modes": [
+					"full_refresh",
+					"incremental"
+				],
+				"source_defined_cursor": true,
+				"json_schema": {
+					"type": "object",
+					"properties": {
+						"id": {
+							"type": "integer"
+						},
+						"name": {
+							"type": "string"
+						},
+						"updated_at": {
+							"type": "string",
+							"format": "date-time"
+						}
+					}
+				}
+			}
 		}
-	  }
-	}
-  ]
+	]
 }

--- a/sample_files/input_data.txt
+++ b/sample_files/input_data.txt
@@ -4,7 +4,7 @@
 {"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379714, "data": {"id": 3,"name": "delta"}}}
 {"type": "RECORD", "record": { "stream": "airbyte_dedup", "emitted_at": 1705379707, "data": {"id": 0, "name": "delta", "updated_at": "2024-03-19T18:05:49.000Z"}}}
 {"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379713, "data": {"id": 4,"name": "american airlines"}}}
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379712, "data": {"id": 5,"name": "qatar airways"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379712, "data": {"id": 5,"name": "qatar airways"}}}
 {"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_overwrite"}}}}
 {"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379711, "data": {"id": 6,"name": "latam"}}}
 {"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379710, "data": {"id": 7,"name": "vivaerobus"}}}

--- a/sample_files/input_data.txt
+++ b/sample_files/input_data.txt
@@ -1,10 +1,14 @@
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379716, "data": {"id": 1,"name": "avianca"}}}
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379715, "data": {"id": 2,"name": "air canada"}}}
-{"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_airlines"}}}}
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379714, "data": {"id": 3,"name": "delta"}}}
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379713, "data": {"id": 4,"name": "american airlines"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379716, "data": {"id": 1,"name": "avianca"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379715, "data": {"id": 2,"name": "air canada"}}}
+{"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_overwrite"}}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379714, "data": {"id": 3,"name": "delta"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_dedup", "emitted_at": 1705379707, "data": {"id": 0,"name": "delta", "updated_at": "2024-03-19T18:05:49.000Z"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379713, "data": {"id": 4,"name": "american airlines"}}}
 {"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379712, "data": {"id": 5,"name": "qatar airways"}}}
-{"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_airlines"}}}}
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379711, "data": {"id": 6,"name": "latam"}}}
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379710, "data": {"id": 7,"name": "vivaerobus"}}}
-{"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379709, "data": {"id": 8,"name": "aeromexico"}}}
+{"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_overwrite"}}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379711, "data": {"id": 6,"name": "latam"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379710, "data": {"id": 7,"name": "vivaerobus"}}}
+{"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_overwrite"}}}}
+{"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379710, "data": {"id": 7,"name": "vivaerobus"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_dedup", "emitted_at": 1705379710, "data": {"id": 1,"name": "avianca", "updated_at": "2024-03-18T18:05:49.000Z"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_dedup", "emitted_at": 1705379711, "data": {"id": 1,"name": "aeromexico", "updated_at": "2024-03-19T18:05:49.000Z"}}}

--- a/sample_files/input_data.txt
+++ b/sample_files/input_data.txt
@@ -2,7 +2,7 @@
 {"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379715, "data": {"id": 2,"name": "air canada"}}}
 {"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_overwrite"}}}}
 {"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379714, "data": {"id": 3,"name": "delta"}}}
-{"type": "RECORD", "record": { "stream": "airbyte_dedup", "emitted_at": 1705379707, "data": {"id": 0,"name": "delta", "updated_at": "2024-03-19T18:05:49.000Z"}}}
+{"type": "RECORD", "record": { "stream": "airbyte_dedup", "emitted_at": 1705379707, "data": {"id": 0, "name": "delta", "updated_at": "2024-03-19T18:05:49.000Z"}}}
 {"type": "RECORD", "record": { "stream": "airbyte_overwrite", "emitted_at": 1705379713, "data": {"id": 4,"name": "american airlines"}}}
 {"type": "RECORD", "record": { "stream": "airbyte_airlines", "emitted_at": 1705379712, "data": {"id": 5,"name": "qatar airways"}}}
 {"type": "STATE", "state": {"state_type": "STREAM", "stream": {"stream_descriptor": {"name":"airbyte_overwrite"}}}}


### PR DESCRIPTION
This PR introduces the destination sync mode `append_dedup` to our destination logic. To review it, keep in mind the three existing destination sync modes. 
1. Overwrite: existing data should be removed and replaced with the incoming data.
2. Append: all incoming data should be appended, leaving duplicates in the Data Pool, if any.
3. Append-dedup: incoming data should be inserted to the Data Pool, deduplicating by primary keys and keeping track of the latest record using the cursor field.

[Sync modes overview official docs.](https://docs.airbyte.com/using-airbyte/core-concepts/sync-modes/)

The sync mode can be chosen after creating a connector and setting its source and destination. But it can also be switched after performing the first sync. For this reason, I added errors in case the initial sync is performed with an `append` mode but then with an `append_dedup` mode, and viceversa. This is because the ORDER BY statement of a Data Pool would depend on said sync mode. 

The code follows this following logic, which is easier to read starting with the path where the Data Source does not exist:
<img width="1233" alt="image" src="https://github.com/propeldata/airbyte-destination/assets/16789333/caafbf7b-fc51-42ac-a8c4-cb07864948b4">
